### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ var batch = new Batchelor({
 		'bearer': [... Google API Token ...]
 	},
 	'headers': {
-		'Content-Type': 'multipart/mixed;'
+		'Content-Type': 'multipart/mixed'
 	}
 });
 ```


### PR DESCRIPTION
request will automatically add semicolon after content-type, if you keep this semicolon then google will return error
