### PR TITLE
forEach to bind this or _self context

### DIFF
--- a/lib/batchelor.js
+++ b/lib/batchelor.js
@@ -68,7 +68,7 @@ Batchelor.prototype.add = function (options) {
 
   //  Check if adding multiple requests and loop through array
   if (!!Array.isArray(options)) {
-    options.forEach(_self.add);
+    options.forEach(_self.add, _self);
 
     return _self;
   }


### PR DESCRIPTION
When I tried the .add method and passed in an array (options), "this" is undefined. Therefore, I think you need to bind "this" for the forEach method. 

Adding _self to bind context solved the problem for me.
