### PR TITLE
Create options.headers if not provided

### DIFF
--- a/lib/batchelor.js
+++ b/lib/batchelor.js
@@ -45,6 +45,7 @@ var Batchelor = function (options) {
 
   //  Defaults options
   options.method = options.method || 'POST'; // Default is POST as this was built specifically for Google
+  if (!options.headers) options.headers = {};
   options.headers['Content-Type'] = options.headers['Content-Type'] || 'multipart/mixed;';
 
   //  Globalise the options


### PR DESCRIPTION
Avoids having to add `headers: {}` when calling the constructor.

```
const batch = new Batchelor({
  'uri':'https://www.googleapis.com',
  'auth': { 'bearer': token },
  'headers': {}
})
```
