### PR TITLE
Send HTTP version in HTTP Request-Line

### DIFF
--- a/lib/batchelor.js
+++ b/lib/batchelor.js
@@ -136,7 +136,7 @@ Batchelor.prototype.run = function (callback) {
     var requestSettings = {
       'Content-Type': 'application/http',
       'Content-ID': requestPart.requestId,
-      'body': requestPart.method + ' ' + requestPart.path + '\n'
+      'body': requestPart.method + ' ' + requestPart.path + ' HTTP/1.1\n'
     };
 
     //  Check if this part needs it's own auth
@@ -146,7 +146,7 @@ Batchelor.prototype.run = function (callback) {
 
     //  Replace body with a request if this isn't a GET
     if (requestPart.method !== 'GET') {
-      requestSettings.body = requestPart.method + ' ' + requestPart.path + '\n' +
+      requestSettings.body = requestPart.method + ' ' + requestPart.path + ' HTTP/1.1\n' +
         'Content-Type: ' + requestPart.parameters['Content-Type'] + '\n\n' +
         JSON.stringify(requestPart.parameters.body);
     }


### PR DESCRIPTION
HTTP Request-Line must include HTTP version.
From the HTTP spec [RFC2616](https://tools.ietf.org/html/rfc2616#section-5.1)

> 5.1 Request-Line
> 
>    The Request-Line begins with a method token, followed by the
>    Request-URI and the protocol version, and ending with CRLF. The
>    elements are separated by SP characters. No CR or LF is allowed
>    except in the final CRLF sequence.
> 
>         Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
