### PR TITLE
Allow quoted multipart/mixed boundaries

### DIFF
--- a/lib/batchelor.js
+++ b/lib/batchelor.js
@@ -171,7 +171,8 @@ Batchelor.prototype.run = function (callback) {
 
     //  Get the boundary
     var boundaryRegex = /^multipart\/.+?(?:; boundary=(?:(?:"(.+)")|(?:([^\s]+))))$/i,
-      boundary = boundaryRegex.exec(responseObj.headers['content-type'])[2],
+      boundaries = boundaryRegex.exec(responseObj.headers['content-type']),
+      boundary = boundaries[1] || boundaries[2],
       responseBody = {
         'parts': [],
         'errors': 0


### PR DESCRIPTION
While the regex supports both quoted and unquoted boundaries, the code previously grabbed only the second capture group (unquoted boundary). This change selects whichever capture group successfully matched.

https://regex101.com/r/XPr4wr/1