### PR TITLE
safely parse json in case of string in body

### DIFF
--- a/lib/batchelor.js
+++ b/lib/batchelor.js
@@ -221,7 +221,11 @@ Batchelor.prototype.run = function (callback) {
 
         //  Parse response JSON
         if (part.data.body) {
-          part.data.body = JSON.parse(part.data.body);
+          try {
+            part.data.body = JSON.parse(part.data.body);
+          } catch (e) {
+            part.data.body = {parseError: part.data.body};
+          }
         }
 
         //  Get the response id if exists


### PR DESCRIPTION
While try to use the versioned batch endpoints and supplying bad URLs, the package crashes while trying to parse the "Not Found" body to an object.

I just added a try/catch to avoid the crash.